### PR TITLE
Add .btn-default to button#addSurvey

### DIFF
--- a/views/index.jade
+++ b/views/index.jade
@@ -98,7 +98,7 @@ block content
       .form-group
         input.form-control(type="url", name="embed", placeholder="URL do obrazka", maxlength=3000)
       button.btn.btn-large.btn-success(type="submit") Wyślij
-      button#addSurvey.btn.btn-large.pull-right(type="button") Dodaj ankietę
+      button#addSurvey.btn.btn-default.btn-large.pull-right(type="button") Dodaj ankietę
       div.surveyForm(style='margin-top: 10px; display: none;')
           .form-group
             input.form-control(type="text", name="survey[question]", placeholder="Wpisz pytanie" minlength="5" maxlength="100")


### PR DESCRIPTION
Hej,

W bootstrapie przyciski domyślnie nie mają ostylowania poprawnego. Wówczas opierają się na domyślnym formatowaniu, które jest dziedziczone z przeglądarki, które - u mnie - nie współgra z samą klasą ```.btn```. Rekomenduje zatem wprost określić, że przycisk ma wygląd domyślny.

Przed zmianami:
![zaznaczenie_1264](https://user-images.githubusercontent.com/3618479/34470280-7ba88ec8-ef2e-11e7-8704-f44dda5a6557.png)

Po zmianach:
![zaznaczenie_1263](https://user-images.githubusercontent.com/3618479/34470276-66a1137e-ef2e-11e7-81bc-5117a142fca9.png)
